### PR TITLE
Add option to export reference image path

### DIFF
--- a/src/napari_roi_manager/_tests/test_widget.py
+++ b/src/napari_roi_manager/_tests/test_widget.py
@@ -109,7 +109,7 @@ def test_read_write(make_napari_viewer: Callable[[], napari.Viewer]):
         roi_manager.save_roiset(path=Path(tmpdir) / "test_save_roiset.json")
 
 
-def test_save_with_image_path(make_napari_viewer: Callable[[], napari.Viewer]):
+def test_save_with_intended_for(make_napari_viewer: Callable[[], napari.Viewer]):
     viewer = make_napari_viewer()
     with tempfile.TemporaryDirectory() as tmpdir:
         image = Path(tmpdir) / "image.tif"
@@ -129,4 +129,4 @@ def test_save_with_image_path(make_napari_viewer: Callable[[], napari.Viewer]):
 
         with open(out_json) as f:
             js = json.load(f)
-        assert js["image_path"] == os.path.relpath(image, start=out_dir)
+        assert js["IntendedFor"] == os.path.relpath(image, start=out_dir)

--- a/src/napari_roi_manager/_tests/test_widget.py
+++ b/src/napari_roi_manager/_tests/test_widget.py
@@ -111,16 +111,21 @@ def test_read_write(make_napari_viewer: Callable[[], napari.Viewer]):
 
 def test_save_with_image_path(make_napari_viewer: Callable[[], napari.Viewer]):
     viewer = make_napari_viewer()
-    roi_manager = QRoiManager(viewer)
-    roi_manager.add(_rectangle(0, 0), shape_type="rectangle")
-    roi_manager.register()
     with tempfile.TemporaryDirectory() as tmpdir:
         image = Path(tmpdir) / "image.tif"
         image.touch()
+        layer = viewer.add_image(np.zeros((5, 5)))
+        layer._source = layer._source._replace(path=str(image))
+
+        roi_manager = QRoiManager(viewer)
+        roi_manager.add(_rectangle(0, 0), shape_type="rectangle")
+        roi_manager.register()
+        roi_manager.set_save_image_path(True)
+
         out_dir = Path(tmpdir) / "out"
         out_dir.mkdir()
         out_json = out_dir / "rois.json"
-        roi_manager.save_roiset(path=out_json, image_path=image)
+        roi_manager.save_roiset(path=out_json)
 
         with open(out_json) as f:
             js = json.load(f)

--- a/src/napari_roi_manager/_tests/test_widget.py
+++ b/src/napari_roi_manager/_tests/test_widget.py
@@ -1,3 +1,5 @@
+import json
+import os
 import tempfile
 from pathlib import Path
 from typing import Callable
@@ -105,3 +107,21 @@ def test_read_write(make_napari_viewer: Callable[[], napari.Viewer]):
     )
     with tempfile.TemporaryDirectory() as tmpdir:
         roi_manager.save_roiset(path=Path(tmpdir) / "test_save_roiset.json")
+
+
+def test_save_with_image_path(make_napari_viewer: Callable[[], napari.Viewer]):
+    viewer = make_napari_viewer()
+    roi_manager = QRoiManager(viewer)
+    roi_manager.add(_rectangle(0, 0), shape_type="rectangle")
+    roi_manager.register()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        image = Path(tmpdir) / "image.tif"
+        image.touch()
+        out_dir = Path(tmpdir) / "out"
+        out_dir.mkdir()
+        out_json = out_dir / "rois.json"
+        roi_manager.save_roiset(path=out_json, image_path=image)
+
+        with open(out_json) as f:
+            js = json.load(f)
+        assert js["image_path"] == os.path.relpath(image, start=out_dir)

--- a/src/napari_roi_manager/layers/_dataclasses.py
+++ b/src/napari_roi_manager/layers/_dataclasses.py
@@ -53,6 +53,7 @@ class RoiData:
     data: list[NDArray[np.number]] = field(default_factory=list)
     shape_type: list[str] = field(default_factory=list)
     names: list[str] | None = field(default_factory=lambda: None)
+    image_path: str | None = None
 
     def to_json_dict(self) -> dict[str, Any]:
         """Convert RoiData to a JSON serializable dictionary."""
@@ -60,6 +61,8 @@ class RoiData:
         out = {"data": data, "shape_type": self.shape_type}
         if self.names is not None:
             out["names"] = self.names
+        if self.image_path is not None:
+            out["image_path"] = self.image_path
         return out
 
     @classmethod
@@ -68,4 +71,5 @@ class RoiData:
         data = [np.array(d) for d in js["data"]]
         shape_type = js["shape_type"]
         names = js.get("names")
-        return RoiData(data, shape_type=shape_type, names=names)
+        image_path = js.get("image_path")
+        return RoiData(data, shape_type=shape_type, names=names, image_path=image_path)

--- a/src/napari_roi_manager/layers/_dataclasses.py
+++ b/src/napari_roi_manager/layers/_dataclasses.py
@@ -62,7 +62,7 @@ class RoiData:
         if self.names is not None:
             out["names"] = self.names
         if self.image_path is not None:
-            out["image_path"] = self.image_path
+            out["IntendedFor"] = self.image_path
         return out
 
     @classmethod
@@ -71,5 +71,5 @@ class RoiData:
         data = [np.array(d) for d in js["data"]]
         shape_type = js["shape_type"]
         names = js.get("names")
-        image_path = js.get("image_path")
+        image_path = js.get("IntendedFor")
         return RoiData(data, shape_type=shape_type, names=names, image_path=image_path)

--- a/src/napari_roi_manager/layers/_layer.py
+++ b/src/napari_roi_manager/layers/_layer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import weakref
 from contextlib import nullcontext
 from enum import Enum
@@ -153,9 +154,29 @@ class RoiManagerLayer(Shapes):
         self.refresh()
         return None
 
-    def write_json(self, path: str | Path) -> None:
-        """Write the ROI data to a JSON file."""
-        js = self.get_roi_data().to_json_dict()
+    def write_json(
+        self, path: str | Path, image_path: str | Path | None = None
+    ) -> None:
+        """Write the ROI data to a JSON file.
+
+        Parameters
+        ----------
+        path : str or Path
+            Destination JSON file.
+        image_path : str or Path, optional
+            Reference image path. When provided, the path is stored relative to
+            the location of the JSON file.
+        """
+        roidata = self.get_roi_data()
+        if image_path is not None:
+            rel = os.path.relpath(Path(image_path), start=Path(path).parent)
+            roidata = RoiData(
+                roidata.data,
+                shape_type=roidata.shape_type,
+                names=roidata.names,
+                image_path=rel,
+            )
+        js = roidata.to_json_dict()
         with open(path, "w") as f:
             json.dump(js, f)
         return None

--- a/src/napari_roi_manager/widgets/_roi_manager.py
+++ b/src/napari_roi_manager/widgets/_roi_manager.py
@@ -46,6 +46,11 @@ class QRoiManagerButtons(QtW.QWidget):
         self._show_all_checkbox = QtW.QCheckBox("Show All", self)
         self._show_all_checkbox.setChecked(True)
 
+        self._save_image_path_checkbox = QtW.QCheckBox("Save image path", self)
+        self._save_image_path_checkbox.setToolTip(
+            "Include reference image path when saving ROIs."
+        )
+
         # add all the widgets
         layout.addWidget(self._add_roi_btn)
         layout.addWidget(self._remove_roi_btn)
@@ -55,6 +60,7 @@ class QRoiManagerButtons(QtW.QWidget):
         layout.addWidget(self._to_shapes_btn)
         layout.addWidget(self._text_group)
         layout.addWidget(self._show_all_checkbox)
+        layout.addWidget(self._save_image_path_checkbox)
 
         self.setFixedWidth(115)
 
@@ -231,6 +237,9 @@ class QRoiManager(QtW.QWidget):
     def set_show_all(self, show_all: bool):
         self._btns._show_all_checkbox.setChecked(show_all)
 
+    def set_save_image_path(self, save: bool):
+        self._btns._save_image_path_checkbox.setChecked(save)
+
     def as_shapes_layer(self):
         shapes = self._layer.as_shapes_layer()
         self._viewer.add_layer(shapes)
@@ -277,4 +286,18 @@ class QRoiManager(QtW.QWidget):
                     return
             else:
                 return
+        if image_path is None and self._btns._save_image_path_checkbox.isChecked():
+            image_path = self._get_reference_image_path()
         self._layer.write_json(path, image_path=image_path)
+
+    def _get_reference_image_path(self):
+        layer = self._viewer.layers.selection.active
+        if layer is None or layer is self._layer:
+            for lyr in self._viewer.layers:
+                if lyr is not self._layer:
+                    layer = lyr
+                    break
+            else:
+                return None
+        source = getattr(layer, "source", None)
+        return getattr(source, "path", None)

--- a/src/napari_roi_manager/widgets/_roi_manager.py
+++ b/src/napari_roi_manager/widgets/_roi_manager.py
@@ -264,7 +264,7 @@ class QRoiManager(QtW.QWidget):
                     return
         self._layer.update_from_json(path, append=append)
 
-    def save_roiset(self, *, path=None):
+    def save_roiset(self, *, path=None, image_path=None):
         if path is None:
             file = QtW.QFileDialog.getSaveFileName(
                 self,
@@ -277,4 +277,4 @@ class QRoiManager(QtW.QWidget):
                     return
             else:
                 return
-        self._layer.write_json(path)
+        self._layer.write_json(path, image_path=image_path)

--- a/src/napari_roi_manager/widgets/_roi_manager.py
+++ b/src/napari_roi_manager/widgets/_roi_manager.py
@@ -46,7 +46,7 @@ class QRoiManagerButtons(QtW.QWidget):
         self._show_all_checkbox = QtW.QCheckBox("Show All", self)
         self._show_all_checkbox.setChecked(True)
 
-        self._save_image_path_checkbox = QtW.QCheckBox("Save image path", self)
+        self._save_image_path_checkbox = QtW.QCheckBox("Save\nimage path", self)
         self._save_image_path_checkbox.setToolTip(
             "Include reference image path when saving ROIs."
         )


### PR DESCRIPTION
## Summary
- allow RoiData to store an optional reference image path
- export ROI sets with image path stored relative to JSON destination
- expose image path option in save_roiset and test relative export

## Testing
- `ruff check --fix src/napari_roi_manager/layers/_dataclasses.py src/napari_roi_manager/layers/_layer.py src/napari_roi_manager/widgets/_roi_manager.py src/napari_roi_manager/_tests/test_widget.py`
- `black src/napari_roi_manager/layers/_dataclasses.py src/napari_roi_manager/layers/_layer.py src/napari_roi_manager/widgets/_roi_manager.py src/napari_roi_manager/_tests/test_widget.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'napari')*
- `pip install napari` *(fails: Could not find a version that satisfies the requirement napari)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bb114624832da474bbeb5f59dc04